### PR TITLE
Added barf

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -14,4 +14,6 @@ repository.url    = git://github.com/rizen/Ouch.git
 repository.web    = http://github.com/rizen/Ouch
 repository.type   = git
 
-
+[Prereq]
+Test::More        = 0
+Test::Trap        = 0

--- a/lib/Ouch.pm
+++ b/lib/Ouch.pm
@@ -5,7 +5,7 @@ use Carp qw(longmess shortmess);
 use parent 'Exporter';
 use overload bool => sub {1}, q{""} => 'scalar', fallback => 1;
 
-our @EXPORT = qw(bleep ouch kiss hug);
+our @EXPORT = qw(bleep ouch kiss hug barf);
 our @EXPORT_OK = qw(try throw catch catch_all);
 our %EXPORT_TAGS = ( traditional => [qw( throw catch try catch_all )] );
 
@@ -68,6 +68,21 @@ sub bleep {
         return $message;
     }
   }
+}
+
+sub barf {
+    my ($e) = @_;
+    my $code;
+    $e ||= $@;
+    if (ref $e eq 'Ouch') {
+        $code = $e->code;
+    } 
+    else {
+        $code = 1;
+    }
+
+    print STDERR bleep($e)."\n";
+    exit $code;
 }
 
 sub scalar {
@@ -254,6 +269,18 @@ Rather than:
 =item exception
 
 Optional. If you like you can pass the exception into C<bleep>. If not, it will just use whatever is in C<$@>.
+
+=back
+
+=head3
+
+Calls C<bleep>, and then exits with error code
+
+=over
+
+=item exception
+
+Optional. You can pass an exception into C<barf> which then gets passed to C<bleep> otherwise it will use whatever's in C<$@>
 
 =back
 

--- a/t/Ouch.t
+++ b/t/Ouch.t
@@ -1,4 +1,5 @@
-use Test::More tests => 23;
+use Test::More tests => 27;
+use Test::Trap;
 use lib '../lib';
 
 use_ok 'Ouch';
@@ -45,3 +46,12 @@ eval { ouch('missing_param', 'Email'); };
 is kiss('missing_param'), 1, 'kiss works on strings';
 is kiss('foo'), 0, 'kiss gives no false positives';
 
+# barf
+trap {eval { ouch(100, 'oops') } or barf() };
+is $trap->exit, 100, 'exit code';
+is $trap->stderr, "oops\n", 'stderr err message';
+
+# more barf
+trap { eval { die 'error' } or barf() };
+is $trap->exit, 1, 'default barf exit code';
+is $trap->stderr, "error\n", 'stderr err message w/o ouch';


### PR DESCRIPTION
- updated prereqs in dist.ini
- added test code and docs for barf

Barf is a sub that calls bleep, and then exits with the desired error code. I do this a few times in my own code that calls, ouch, and I figured it would be nice to have in Ouch proper.

I also updated the dist.ini to include a dependency on Test::More as well as Test::Trap which I used to test barf's exit behavior.
