### PR TITLE
Include missing prereqs

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -17,3 +17,7 @@ repository.type   = git
 [Prereqs]
 Test::More        = 0
 Test::Trap        = 0
+parent            = 0
+overload          = 0
+Carp              = 0
+


### PR DESCRIPTION
Add missing prerequisites causing test failures.

Placing a 'use 5.012' appears to have been overkill.  With the prerequisites installed, the build and test succeeds.

Note: 0.0405 is not on github.  Will rebase if your source is pushed.

Obviously if #4 is your stance, then so be it, your code, your rules :-)
