### PR TITLE
catch subclasses of Ouch as well

### DIFF
--- a/lib/Ouch.pm
+++ b/lib/Ouch.pm
@@ -4,6 +4,7 @@ package Ouch;
 use Carp qw(longmess shortmess);
 use parent 'Exporter';
 use overload bool => sub {1}, q{""} => 'scalar', fallback => 1;
+use Scalar::Util qw(blessed);
 
 our @EXPORT = qw(bleep ouch kiss hug barf);
 our @EXPORT_OK = qw(try throw catch catch_all caught caught_all);
@@ -33,7 +34,7 @@ sub throw {  # alias
 sub kiss {
   my ($code, $e) = @_;
   $e ||= $@;
-  if (ref $e eq 'Ouch' && $e->code eq $code) {
+  if (blessed $e && $e->isa('Ouch') && $e->code eq $code) {
     return 1;
   }
   return 0;
@@ -64,7 +65,7 @@ sub caught_all {
 sub bleep {
   my ($e) = @_;
   $e ||= $@;
-  if (ref $e eq 'Ouch') {
+  if (blessed $e && $e->isa('Ouch')) {
     return $e->message;
   }
   else {
@@ -82,7 +83,7 @@ sub barf {
     my ($e) = @_;
     my $code;
     $e ||= $@;
-    if (ref $e eq 'Ouch') {
+    if (blessed $e && $e->isa('Ouch')) {
         $code = $e->code;
     } 
     else {

--- a/t/subclass.t
+++ b/t/subclass.t
@@ -1,0 +1,14 @@
+use Test::More tests => 2;
+use Test::Trap;
+use lib '../lib';
+
+use_ok 'Ouch';
+
+{
+  package Subclass::Ouch;
+  use parent 'Ouch';
+}
+
+eval { die Subclass::Ouch->new(42, 'welp') };
+is kiss(42), 1, 'still catches subclasses';
+


### PR DESCRIPTION
If something constructs a subclass of Ouch, it should still be caught by the subs in this module.

The main motivation for this change is that I have a module Carp::Always::WithObjects that forces all exceptions to have stack traces.  It does this by auto-subclassing any exception objects that get thrown.  This doesn't work for Ouch as is, because it checks the exact class name of the object instead of using isa.
