### PR TITLE
Update Build.PL to include missing dependency

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -8,7 +8,8 @@ my $builder = Module::Build->new(
 	'license' => 'perl',
 	'dist_author' => 'JT Smith',
 	'build_requires' => {
-		'Test::More' => 0
+		'Test::More' => 0,
+		'Test::Trap' => 0,
 	},
 	'create_makefile_pl' => 'traditional'
 );


### PR DESCRIPTION
Test::Trap is required by the tests for Ouch. It is included in dist.ini but not in Build.PL. As others have said, the real solution is to remove Build.PL from the distribution, but this patch will make the dist build OK.